### PR TITLE
[MODORDSTOR-454] Remove COMMIT statement from POL holding link update script

### DIFF
--- a/src/main/resources/db_scripts/update_pol_holding_links/update_pol_holding_links.sql
+++ b/src/main/resources/db_scripts/update_pol_holding_links/update_pol_holding_links.sql
@@ -137,8 +137,6 @@ END LOOP;
 
 RAISE NOTICE E'[MIGRATION] PO Line location update script "%" finished. POL(s) updated: %\n', script_name, updated_count;
 
-COMMIT;
-
 EXCEPTION WHEN others THEN
     RAISE EXCEPTION '[MIGRATION] Failed to execute script "%", error: %, SQLSTATE: %', script_name, SQLERRM, SQLSTATE;
 


### PR DESCRIPTION
## Purpose
[[MODORDSTOR-454] Create migration script for updating PO Line holdings links](https://folio-org.atlassian.net/browse/MODORDSTOR-454)

## Approach
Remove COMMIT statement from POL holding link update script

## Resources
Update script:
TODO